### PR TITLE
Adds support for RFC3339_EXTENDED format

### DIFF
--- a/src/Enum/DateTimePlus/FormatWithTimezone.php
+++ b/src/Enum/DateTimePlus/FormatWithTimezone.php
@@ -20,11 +20,15 @@ enum FormatWithTimezone: string
     /** ex: 'Saturday, 01-Jan-2022 12:00:00 GMT+0000'; */
     case COOKIE = 'COOKIE';
 
+    /** ex: 022-01-01T12:00:00.000+00:00 */
+    case RFC3339_EXTENDED = 'RFC3339_EXTENDED';
+
     public function pattern(): string
     {
         return match ($this) {
             self::ATOM => 'Y-m-d\TH:i:sP',
             self::COOKIE => 'l, d-M-Y H:i:s T',
+            self::RFC3339_EXTENDED => 'Y-m-d\TH:i:s.vP',
         };
     }
 }


### PR DESCRIPTION
[RFC 3339 EXTENDED format](https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.rfc3339-extended) is the same as ATOM, but with milliseconds.